### PR TITLE
update documentation for output_type_id to note that values should be specified in order

### DIFF
--- a/v3.0.0/tasks-schema.json
+++ b/v3.0.0/tasks-schema.json
@@ -906,7 +906,7 @@
                                             "type": "object",
                                             "properties": {
                                                 "output_type_id": {
-                                                    "description": "Object containing required and optional arrays defining possible values of the target variable at which values of the cumulative distribution function of the predictive distribution will be recorded.",
+                                                    "description": "Object containing required and optional arrays defining possible values of the target variable at which values of the cumulative distribution function of the predictive distribution will be recorded. These should be listed in order from low to high.",
                                                     "examples": [{
                                                             "required": [
                                                                 10.0,
@@ -1021,7 +1021,7 @@
                                             "type": "object",
                                             "properties": {
                                                 "output_type_id": {
-                                                    "description": "Object containing required and optional arrays specifying valid categories of a discrete variable.",
+                                                    "description": "Object containing required and optional arrays specifying valid categories of a discrete variable. Note that for ordinal variables, the category levels should be listed in order from low to high.",
                                                     "examples": [{
                                                         "required": null,
                                                         "optional": [


### PR DESCRIPTION
This PR would address #85. Because this change is only being made to documentation, I have not incremented the schema version.  I'm also happy to update to schema version 3.0.1 if that would be better.