### PR TITLE
Diff comment workflow

### DIFF
--- a/.github/workflows/comment-diff.yaml
+++ b/.github/workflows/comment-diff.yaml
@@ -1,0 +1,45 @@
+name: "Generate New Spec Diff"
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  comment-changed-workflow:
+    name: 'Comment Spec Diff'
+    runs-on: ubuntu-latest
+    if: ${{ github.event.issue.pull_request && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER') && startsWith(github.event.comment.body, '/diff') }}
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: r-lib/actions/pr-fetch@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Record DIFF"
+        id: dl
+        run: |
+          echo "body<<EOF" >> $GITHUB_ENV
+          echo "" >> $GITHUB_ENV
+          old=$(ls -d */ | sort | tail -n 2 | head -n 1)
+          new=$(ls -d */ | sort | tail -n 1)
+          echo "Here are your diffs for this pull request" >> $GITHUB_ENV
+          echo "" >> $GITHUB_ENV
+          echo '## `admin-schema.json`' >> $GITHUB_ENV
+          echo "" >> $GITHUB_ENV
+          echo '```diff' >> $GITHUB_ENV
+          echo "$(diff -u ${old}admin-schema.json ${new}admin-schema.json)" >> $GITHUB_ENV
+          echo '```' >> $GITHUB_ENV
+          echo "" >> $GITHUB_ENV
+          echo '## `tasks-schema.json`' >> $GITHUB_ENV
+          echo "" >> $GITHUB_ENV
+          echo '```diff' >> $GITHUB_ENV
+          echo "$(diff -u ${old}tasks-schema.json ${new}tasks-schema.json)" >> $GITHUB_ENV
+          echo '```' >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+      - name: "Comment on PR"
+        uses: carpentries/actions/comment-diff@5d73d6a34b013488264890868d8eeab1edffdf2e
+        with:
+          pr: ${{ github.event.issue.number }}
+          body: ${{ env.body }}
+

--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ diff -u --color=always $(ls -d */ | sort | tail -n 2 | head -n 1)tasks-schema.js
 > ```
 >
 > #### Send output directly to clipboard
-
 > Depending on your system (macOS or Linux), you can pipe the output of the above commands directly to the clipboard. See examples below:
 > 
 > ##### macOS:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,19 @@ After making a new release to the schema repository, ensure `hubDocs` are also a
 
 ## Highlighting changes to schema in PRs
 
-To bring attention to the changes in new schema versions, it's useful to include in any PR, a print out of the diffs in the `tasks-schema.json` and `admin-schema.json` files compared to the previous version. To print the diffs in each file you can use the following commands in the terminal:
+To bring attention to the changes in new schema versions, it's useful to include in any PR, a print out of the diffs in the `tasks-schema.json` and `admin-schema.json` files compared to the previous version. 
+
+### Automated Process (via GitHub)
+
+After you create a new Pull Request, if you create a new comment with `/diff`, GitHub will automatically generate the diffs of the `tasks-schema.json` and `admin-schema.json` and comment on the pull request.
+
+If you need to update the schema after review, you can update the diffs by creating another `/diff` comment.
+
+If this does not work for any reason, you can follow the manual process below.
+
+### Manual Process
+
+To print the diffs in each file you can use the following commands in the terminal:
 
 #### `admin-schema.json`
 
@@ -63,6 +75,7 @@ diff -u --color=always $(ls -d */ | sort | tail -n 2 | head -n 1)tasks-schema.js
 > ```
 >
 > #### Send output directly to clipboard
+
 > Depending on your system (macOS or Linux), you can pipe the output of the above commands directly to the clipboard. See examples below:
 > 
 > ##### macOS:


### PR DESCRIPTION
This workflow will run whenever one of use (the repo owners) adds the `/diff` comment in a pull request. It will generate a highlighted diff of the schema as a GitHub comment. 

This uses two external actions

 - [r-lib/pr-fetch](https://github.com/r-lib/actions/tree/v2-branch/pr-fetch) to check out the PR from a comment
 - [carpentries/comment-diff](https://github.com/carpentries/actions/tree/main/comment-diff) to create and subsequently update a comment with GitHub's API (I wrote this one at my previous job)


I've updated the README to highlight the automatic generation of diffs, while leaving @annakrystalli instructions for manually creating the diffs as a backup