### PR TITLE
Use jq to un-collapse arrays

### DIFF
--- a/v3.0.1/admin-schema.json
+++ b/v3.0.1/admin-schema.json
@@ -7,19 +7,25 @@
     "properties": {
         "schema_version": {
             "description": "URL to a version of the Modeling Hub schema admin-schema.json file (see https://github.com/hubverse-org/schemas). Used to declare the schema version an 'admin.json' file is written for and for config file validation. The URL provided should be the URL to the raw content of the schema file on GitHub.",
-            "examples": ["https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/admin-schema.json"],
+            "examples": [
+                "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/admin-schema.json"
+            ],
             "type": "string",
             "format": "uri"
         },
         "name": {
             "description": "The name of the hub.",
             "type": "string",
-            "examples": ["US COVID-19 Forecast Hub​"]
+            "examples": [
+                "US COVID-19 Forecast Hub​"
+            ]
         },
         "maintainer": {
             "description": "The entity that maintains and runs the hub.",
             "type": "string",
-            "examples": ["The Consortium of Infectious Disease Modeling Hubs"]
+            "examples": [
+                "The Consortium of Infectious Disease Modeling Hubs"
+            ]
         },
         "contact": {
             "description": "The name and email of a human being who serves as a point of contact for the hub.",
@@ -36,17 +42,21 @@
         },
         "repository": {
             "description": "Object containing details of the hub repository.",
-            "examples": [{
-                "host": "github",
-                "owner": "hubverse-org",
-                "name": "example-simple-forecast-hub"
-            }],
+            "examples": [
+                {
+                    "host": "github",
+                    "owner": "hubverse-org",
+                    "name": "example-simple-forecast-hub"
+                }
+            ],
             "type": "object",
             "properties": {
                 "host": {
                     "description": "The name of the web host for the hub repository",
                     "type": "string",
-                    "enum": ["github"]
+                    "enum": [
+                        "github"
+                    ]
                 },
                 "owner": {
                     "type": "string"
@@ -59,18 +69,27 @@
         "zoltar_project_id": {
             "description": "The project id of the Hub in Zoltar",
             "type": "integer",
-            "examples": [44]
+            "examples": [
+                44
+            ]
         },
         "citation": {
             "description": "One or more citations for the hub.",
             "type": "string",
-            "examples": ["Cramer, E.Y., Huang, Y., Wang, Y. et al. The United States COVID-19 Forecast Hub dataset. Sci Data 9, 462 (2022). https://doi.org/10.1038/s41597-022-01517-w"]
+            "examples": [
+                "Cramer, E.Y., Huang, Y., Wang, Y. et al. The United States COVID-19 Forecast Hub dataset. Sci Data 9, 462 (2022). https://doi.org/10.1038/s41597-022-01517-w"
+            ]
         },
         "file_format": {
             "description": "Accepted file formats of model output files.",
             "examples": [
-                ["arrow", "parquet"],
-                ["csv"]
+                [
+                    "arrow",
+                    "parquet"
+                ],
+                [
+                    "csv"
+                ]
             ],
             "type": "array",
             "items": {
@@ -624,20 +643,30 @@
             "description": "Optional settings for cloud-enabled hubs",
             "type": "object",
             "properties": {
-                "enabled": {"type": "boolean"},
+                "enabled": {
+                    "type": "boolean"
+                },
                 "host": {
                     "type": "object",
-                    "required": ["name", "storage_service", "storage_location"],
+                    "required": [
+                        "name",
+                        "storage_service",
+                        "storage_location"
+                    ],
                     "properties": {
                         "name": {
                             "description": "Name of the cloud storage provider.",
                             "type": "string",
-                            "enum": ["aws"]
+                            "enum": [
+                                "aws"
+                            ]
                         },
                         "storage_service": {
                             "description": "Name of the cloud service used as backend storage",
                             "type": "string",
-                            "enum": ["s3"]
+                            "enum": [
+                                "s3"
+                            ]
                         },
                         "storage_location": {
                             "description": "Cloud storage location, excluding prefix (for example, AWS S3 bucket name).",
@@ -648,11 +677,15 @@
             },
             "if": {
                 "properties": {
-                    "enabled": {"const": true}
+                    "enabled": {
+                        "const": true
+                    }
                 }
             },
             "then": {
-                "required": ["host"]
+                "required": [
+                    "host"
+                ]
             },
             "examples": [
                 {

--- a/v3.0.1/tasks-schema.json
+++ b/v3.0.1/tasks-schema.json
@@ -7,7 +7,9 @@
     "properties": {
         "schema_version": {
             "description": "URL to a version of the Modeling Hub schema tasks-schema.json file (see https://github.com/hubverse-org/schemas). Used to declare the schema version a 'tasks.json' file is written for and for config file validation. The URL provided should be the URL to the raw content of the schema file on GitHub.",
-            "examples": ["https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json"],
+            "examples": [
+                "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json"
+            ],
             "type": "string",
             "format": "uri"
         },
@@ -50,14 +52,16 @@
                                     "properties": {
                                         "origin_date": {
                                             "description": "An object containing arrays of required and optional unique origin dates. Origin date defines the starting point that can be used for calculating a target_date via the formula target_date = origin_date + horizon x time_units_per_horizon (e.g., with weekly data, target_date is calculated as origin_date + horizon x 7 days)",
-                                            "examples": [{
-                                                "required": null,
-                                                "optional": [
-                                                    "2022-11-05",
-                                                    "2022-11-12",
-                                                    "2022-11-19"
-                                                ]
-                                            }],
+                                            "examples": [
+                                                {
+                                                    "required": null,
+                                                    "optional": [
+                                                        "2022-11-05",
+                                                        "2022-11-12",
+                                                        "2022-11-19"
+                                                    ]
+                                                }
+                                            ],
                                             "type": "object",
                                             "properties": {
                                                 "required": {
@@ -92,14 +96,16 @@
                                         },
                                         "forecast_date": {
                                             "description": "An object containing arrays of required and optional unique forecast dates. Forecast date usually defines the date that a model is run to produce a forecast.",
-                                            "examples": [{
-                                                "required": null,
-                                                "optional": [
-                                                    "2022-11-05",
-                                                    "2022-11-12",
-                                                    "2022-11-19"
-                                                ]
-                                            }],
+                                            "examples": [
+                                                {
+                                                    "required": null,
+                                                    "optional": [
+                                                        "2022-11-05",
+                                                        "2022-11-12",
+                                                        "2022-11-19"
+                                                    ]
+                                                }
+                                            ],
                                             "type": "object",
                                             "properties": {
                                                 "required": {
@@ -134,7 +140,8 @@
                                         },
                                         "scenario_id": {
                                             "description": "An object containing arrays of required and optional unique identifiers of each valid scenario.",
-                                            "examples": [{
+                                            "examples": [
+                                                {
                                                     "required": null,
                                                     "optional": [
                                                         1,
@@ -191,62 +198,64 @@
                                         },
                                         "location": {
                                             "description": "An object containing arrays of required and optional unique identifiers for each valid location, e.g. country codes, FIPS state or county level code etc.",
-                                            "examples": [{
-                                                "required": "US",
-                                                "optional": [
-                                                    "01",
-                                                    "02",
-                                                    "04",
-                                                    "05",
-                                                    "06",
-                                                    "08",
-                                                    "09",
-                                                    "10",
-                                                    "11",
-                                                    "12",
-                                                    "13",
-                                                    "15",
-                                                    "16",
-                                                    "17",
-                                                    "18",
-                                                    "19",
-                                                    "20",
-                                                    "21",
-                                                    "22",
-                                                    "23",
-                                                    "24",
-                                                    "25",
-                                                    "26",
-                                                    "27",
-                                                    "28",
-                                                    "29",
-                                                    "30",
-                                                    "31",
-                                                    "32",
-                                                    "33",
-                                                    "34",
-                                                    "35",
-                                                    "36",
-                                                    "37",
-                                                    "38",
-                                                    "39",
-                                                    "40",
-                                                    "41",
-                                                    "42",
-                                                    "44",
-                                                    "45",
-                                                    "46",
-                                                    "47",
-                                                    "48",
-                                                    "49",
-                                                    "50",
-                                                    "51",
-                                                    "53",
-                                                    "54",
-                                                    "55",
-                                                    "56"
-                                                ]
-                                            }],
+                                            "examples": [
+                                                {
+                                                    "required": "US",
+                                                    "optional": [
+                                                        "01",
+                                                        "02",
+                                                        "04",
+                                                        "05",
+                                                        "06",
+                                                        "08",
+                                                        "09",
+                                                        "10",
+                                                        "11",
+                                                        "12",
+                                                        "13",
+                                                        "15",
+                                                        "16",
+                                                        "17",
+                                                        "18",
+                                                        "19",
+                                                        "20",
+                                                        "21",
+                                                        "22",
+                                                        "23",
+                                                        "24",
+                                                        "25",
+                                                        "26",
+                                                        "27",
+                                                        "28",
+                                                        "29",
+                                                        "30",
+                                                        "31",
+                                                        "32",
+                                                        "33",
+                                                        "34",
+                                                        "35",
+                                                        "36",
+                                                        "37",
+                                                        "38",
+                                                        "39",
+                                                        "40",
+                                                        "41",
+                                                        "42",
+                                                        "44",
+                                                        "45",
+                                                        "46",
+                                                        "47",
+                                                        "48",
+                                                        "49",
+                                                        "50",
+                                                        "51",
+                                                        "53",
+                                                        "54",
+                                                        "55",
+                                                        "56"
+                                                    ]
+                                                }
+                                            ],
                                             "type": "object",
                                             "properties": {
                                                 "required": {
@@ -280,17 +289,22 @@
                                         "target": {
                                             "description": "An object containing arrays of required and optional unique identifiers for each valid target. Usually represents a single task ID target key variable.",
                                             "type": "object",
-                                            "examples": [{
-                                                "required": null,
-                                                "optional": [
-                                                    "inc hosp",
-                                                    "inc case",
-                                                    "inc death"
-                                                ]
-                                            }, {
-                                                "required": ["peak week inc hosp"],
-                                                "optional": null
-                                            }],
+                                            "examples": [
+                                                {
+                                                    "required": null,
+                                                    "optional": [
+                                                        "inc hosp",
+                                                        "inc case",
+                                                        "inc death"
+                                                    ]
+                                                },
+                                                {
+                                                    "required": [
+                                                        "peak week inc hosp"
+                                                    ],
+                                                    "optional": null
+                                                }
+                                            ],
                                             "properties": {
                                                 "required": {
                                                     "description": "Array of target unique identifiers that must be present for submission to be valid. Can be null if no targets are required and all valid targets are specified in the optional property.",
@@ -323,13 +337,24 @@
                                         "target_variable": {
                                             "description": "An object containing arrays of required and optional unique identifiers for each valid target variable. Usually forms part of a pair of task ID target key variables (along with target_outcome) which combine to define individual targets.",
                                             "type": "object",
-                                            "examples": [{
-                                                "required": null,
-                                                "optional": ["hosp", "death", "case"]
-                                            }, {
-                                                "required": ["hosp"],
-                                                "optional": ["case"]
-                                            }],
+                                            "examples": [
+                                                {
+                                                    "required": null,
+                                                    "optional": [
+                                                        "hosp",
+                                                        "death",
+                                                        "case"
+                                                    ]
+                                                },
+                                                {
+                                                    "required": [
+                                                        "hosp"
+                                                    ],
+                                                    "optional": [
+                                                        "case"
+                                                    ]
+                                                }
+                                            ],
                                             "properties": {
                                                 "required": {
                                                     "description": "Array of target variable unique identifiers that must be present for submission to be valid. Can be null if no target variables are required and all valid target variables are specified in the optional property.",
@@ -362,13 +387,22 @@
                                         "target_outcome": {
                                             "description": "An object containing arrays of required and optional unique identifiers for each valid target outcome. Usually forms part of a pair of task ID target key variables (along with target_variable) which combine to define individual targets.",
                                             "type": "object",
-                                            "examples": [{
-                                                "required": ["inc"],
-                                                "optional": null
-                                            }, {
-                                                "required": ["inc"],
-                                                "optional": ["cum"]
-                                            }],
+                                            "examples": [
+                                                {
+                                                    "required": [
+                                                        "inc"
+                                                    ],
+                                                    "optional": null
+                                                },
+                                                {
+                                                    "required": [
+                                                        "inc"
+                                                    ],
+                                                    "optional": [
+                                                        "cum"
+                                                    ]
+                                                }
+                                            ],
                                             "properties": {
                                                 "required": {
                                                     "description": "Array of target outcome unique identifiers that must be present for submission to be valid. Can be null if no target outcomes are required and all valid target outcomes are specified in the optional property.",
@@ -400,14 +434,16 @@
                                         },
                                         "target_date": {
                                             "description": "An object containing arrays of required and optional unique target dates. For short-term forecasts, the target_date specifies the date of occurrence of the outcome of interest. For instance, if models are requested to forecast the number of hospitalizations that will occur on 2022-07-15, the target_date is 2022-07-15",
-                                            "examples": [{
-                                                "required": null,
-                                                "optional": [
-                                                    "2022-11-12",
-                                                    "2022-11-19",
-                                                    "2022-11-26"
-                                                ]
-                                            }],
+                                            "examples": [
+                                                {
+                                                    "required": null,
+                                                    "optional": [
+                                                        "2022-11-12",
+                                                        "2022-11-19",
+                                                        "2022-11-26"
+                                                    ]
+                                                }
+                                            ],
                                             "type": "object",
                                             "properties": {
                                                 "required": {
@@ -442,14 +478,16 @@
                                         },
                                         "target_end_date": {
                                             "description": "An object containing arrays of required and optional unique target end dates. For short-term forecasts, the target_end_date specifies the date of occurrence of the outcome of interest. For instance, if models are requested to forecast the number of hospitalizations that will occur on 2022-07-15, the target_end_date is 2022-07-15",
-                                            "examples": [{
-                                                "required": null,
-                                                "optional": [
-                                                    "2022-11-12",
-                                                    "2022-11-19",
-                                                    "2022-11-26"
-                                                ]
-                                            }],
+                                            "examples": [
+                                                {
+                                                    "required": null,
+                                                    "optional": [
+                                                        "2022-11-12",
+                                                        "2022-11-19",
+                                                        "2022-11-26"
+                                                    ]
+                                                }
+                                            ],
                                             "type": "object",
                                             "properties": {
                                                 "required": {
@@ -484,15 +522,17 @@
                                         },
                                         "horizon": {
                                             "description": "An object containing arrays of required and optional unique horizons. Horizons define the difference between the target_date and the origin_date in time units specified by the hub (e.g., may be days, weeks, or months)",
-                                            "examples": [{
-                                                "required": null,
-                                                "optional": [
-                                                    1,
-                                                    2,
-                                                    3,
-                                                    4
-                                                ]
-                                            }],
+                                            "examples": [
+                                                {
+                                                    "required": null,
+                                                    "optional": [
+                                                        1,
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ]
+                                                }
+                                            ],
                                             "type": "object",
                                             "properties": {
                                                 "required": {
@@ -532,16 +572,18 @@
                                         "age_group": {
                                             "type": "object",
                                             "description": "An object containing arrays of required and optional unique identifiers for age groups",
-                                            "examples": [{
-                                                "required": [
-                                                    "0-5",
-                                                    "6-18",
-                                                    "19-24",
-                                                    "25-64",
-                                                    "65+"
-                                                ],
-                                                "optional": null
-                                            }],
+                                            "examples": [
+                                                {
+                                                    "required": [
+                                                        "0-5",
+                                                        "6-18",
+                                                        "19-24",
+                                                        "25-64",
+                                                        "65+"
+                                                    ],
+                                                    "optional": null
+                                                }
+                                            ],
                                             "properties": {
                                                 "required": {
                                                     "description": "Array of age group unique identifiers that must be present for submission to be valid. Can be null if no age groups are required and all valid age groups are specified in the optional property.",
@@ -609,7 +651,8 @@
                                             "properties": {
                                                 "output_type_id": {
                                                     "description": "output_type_id is not meaningful for a mean output_type. The property is primarily used to determine whether mean is a required or optional output type through properties required and optional. If mean is a required output type, the required property must be an array containing the single string element 'NA' and the optional property must be set to null. If mean is an optional output type, the optional property must be an array containing the single string element 'NA' and the required property must be set to null",
-                                                    "examples": [{
+                                                    "examples": [
+                                                        {
                                                             "required": [
                                                                 "NA"
                                                             ],
@@ -623,7 +666,8 @@
                                                         }
                                                     ],
                                                     "type": "object",
-                                                    "oneOf": [{
+                                                    "oneOf": [
+                                                        {
                                                             "properties": {
                                                                 "required": {
                                                                     "description": "When mean is required, property set to single element 'NA' array",
@@ -664,10 +708,12 @@
                                                 "value": {
                                                     "type": "object",
                                                     "description": "Object defining the characteristics of valid mean values.",
-                                                    "examples": [{
-                                                        "type": "double",
-                                                        "minimum": 0
-                                                    }],
+                                                    "examples": [
+                                                        {
+                                                            "type": "double",
+                                                            "minimum": 0
+                                                        }
+                                                    ],
                                                     "properties": {
                                                         "type": {
                                                             "description": "Data type of mean values.",
@@ -708,7 +754,8 @@
                                             "properties": {
                                                 "output_type_id": {
                                                     "description": "output_type_id is not meaningful for a median output_type. The property is primarily used to determine whether median is a required or optional output type through properties required and optional. If median is a required output type, the required property must be an array containing the single string element 'NA' and the optional property must be set to null. If median is an optional output type, the optional property must be an array containing the single string element 'NA' and the required property must be set to null",
-                                                    "examples": [{
+                                                    "examples": [
+                                                        {
                                                             "required": [
                                                                 "NA"
                                                             ],
@@ -722,7 +769,8 @@
                                                         }
                                                     ],
                                                     "type": "object",
-                                                    "oneOf": [{
+                                                    "oneOf": [
+                                                        {
                                                             "properties": {
                                                                 "required": {
                                                                     "description": "When median is required, property set to single element 'NA' array",
@@ -763,10 +811,12 @@
                                                 "value": {
                                                     "type": "object",
                                                     "description": "Object defining the characteristics of valid median values",
-                                                    "examples": [{
-                                                        "type": "double",
-                                                        "minimum": 0
-                                                    }],
+                                                    "examples": [
+                                                        {
+                                                            "type": "double",
+                                                            "minimum": 0
+                                                        }
+                                                    ],
                                                     "properties": {
                                                         "type": {
                                                             "description": "Data type of median values",
@@ -807,23 +857,25 @@
                                             "properties": {
                                                 "output_type_id": {
                                                     "description": "Object containing required and optional arrays defining the probability levels at which quantiles of the predictive distribution will be recorded.",
-                                                    "examples": [{
-                                                        "required": [
-                                                            0.25,
-                                                            0.5,
-                                                            0.75
-                                                        ],
-                                                        "optional": [
-                                                            0.1,
-                                                            0.2,
-                                                            0.3,
-                                                            0.4,
-                                                            0.6,
-                                                            0.7,
-                                                            0.8,
-                                                            0.9
-                                                        ]
-                                                    }],
+                                                    "examples": [
+                                                        {
+                                                            "required": [
+                                                                0.25,
+                                                                0.5,
+                                                                0.75
+                                                            ],
+                                                            "optional": [
+                                                                0.1,
+                                                                0.2,
+                                                                0.3,
+                                                                0.4,
+                                                                0.6,
+                                                                0.7,
+                                                                0.8,
+                                                                0.9
+                                                            ]
+                                                        }
+                                                    ],
                                                     "type": "object",
                                                     "properties": {
                                                         "required": {
@@ -907,10 +959,11 @@
                                             "properties": {
                                                 "output_type_id": {
                                                     "description": "Object containing required and optional arrays defining possible values of the target variable at which values of the cumulative distribution function of the predictive distribution will be recorded. These should be listed in order from low to high.",
-                                                    "examples": [{
+                                                    "examples": [
+                                                        {
                                                             "required": [
-                                                                10.0,
-                                                                20.0
+                                                                10,
+                                                                20
                                                             ],
                                                             "optional": null
                                                         },
@@ -938,7 +991,8 @@
                                                             ],
                                                             "uniqueItems": true,
                                                             "items": {
-                                                                "oneOf": [{
+                                                                "oneOf": [
+                                                                    {
                                                                         "type": [
                                                                             "number",
                                                                             "integer"
@@ -959,7 +1013,8 @@
                                                             ],
                                                             "uniqueItems": true,
                                                             "items": {
-                                                                "oneOf": [{
+                                                                "oneOf": [
+                                                                    {
                                                                         "type": [
                                                                             "number",
                                                                             "integer"
@@ -1016,15 +1071,17 @@
                                             "properties": {
                                                 "output_type_id": {
                                                     "description": "Object containing required and optional arrays specifying valid categories of a discrete variable. Note that for ordinal variables, the category levels should be listed in order from low to high.",
-                                                    "examples": [{
-                                                        "required": null,
-                                                        "optional": [
-                                                            "low",
-                                                            "moderate",
-                                                            "high",
-                                                            "extreme"
-                                                        ]
-                                                    }],
+                                                    "examples": [
+                                                        {
+                                                            "required": null,
+                                                            "optional": [
+                                                                "low",
+                                                                "moderate",
+                                                                "high",
+                                                                "extreme"
+                                                            ]
+                                                        }
+                                                    ],
                                                     "type": "object",
                                                     "properties": {
                                                         "required": {
@@ -1058,11 +1115,13 @@
                                                 "value": {
                                                     "type": "object",
                                                     "description": "Object defining valid values of the probability mass function of the predictive distribution for a given category of a discrete outcome variable.",
-                                                    "examples": [{
-                                                        "type": "double",
-                                                        "minimum": 0,
-                                                        "maximum": 1
-                                                    }],
+                                                    "examples": [
+                                                        {
+                                                            "type": "double",
+                                                            "minimum": 0,
+                                                            "maximum": 1
+                                                        }
+                                                    ],
                                                     "properties": {
                                                         "type": {
                                                             "description": "Data type of the probability mass function values.",
@@ -1095,23 +1154,31 @@
                                             "properties": {
                                                 "output_type_id_params": {
                                                     "description": "Object containing parameters specifying how samples were drawn.",
-                                                    "examples": [{
-                                                        "output_type_id_params": {
-                                                            "is_required": true,
-                                                            "type": "integer",
-                                                            "min_samples_per_task": 100,
-                                                            "max_samples_per_task": 100
+                                                    "examples": [
+                                                        {
+                                                            "output_type_id_params": {
+                                                                "is_required": true,
+                                                                "type": "integer",
+                                                                "min_samples_per_task": 100,
+                                                                "max_samples_per_task": 100
+                                                            }
+                                                        },
+                                                        {
+                                                            "output_type_id_params": {
+                                                                "is_required": false,
+                                                                "type": "character",
+                                                                "max_length": 6,
+                                                                "min_samples_per_task": 100,
+                                                                "max_samples_per_task": 500,
+                                                                "compound_taskid_set": [
+                                                                    "origin_date",
+                                                                    "horizon",
+                                                                    "location",
+                                                                    "variant"
+                                                                ]
+                                                            }
                                                         }
-                                                    }, {
-                                                        "output_type_id_params": {
-                                                            "is_required": false,
-                                                            "type": "character",
-                                                            "max_length": 6,
-                                                            "min_samples_per_task": 100,
-                                                            "max_samples_per_task": 500,
-                                                            "compound_taskid_set" : ["origin_date", "horizon", "location", "variant"]
-                                                        }
-                                                    }],
+                                                    ],
                                                     "type": "object",
                                                     "properties": {
                                                         "is_required": {
@@ -1150,7 +1217,6 @@
                                                             "items": {
                                                                 "type": "string"
                                                             }
-                                                            
                                                         }
                                                     },
                                                     "required": [
@@ -1161,11 +1227,15 @@
                                                     ],
                                                     "if": {
                                                         "properties": {
-                                                            "type": { "const": "character" }
+                                                            "type": {
+                                                                "const": "character"
+                                                            }
                                                         }
                                                     },
                                                     "then": {
-                                                        "required": ["max_length"]
+                                                        "required": [
+                                                            "max_length"
+                                                        ]
                                                     }
                                                 },
                                                 "value": {
@@ -1174,9 +1244,11 @@
                                                     "properties": {
                                                         "type": {
                                                             "description": "Data type of sample value from the predictive distribution.",
-                                                            "examples": [{
-                                                                "type": "double"
-                                                            }],
+                                                            "examples": [
+                                                                {
+                                                                    "type": "double"
+                                                                }
+                                                            ],
                                                             "type": "string",
                                                             "enum": [
                                                                 "double",
@@ -1248,7 +1320,8 @@
                                             },
                                             "target_keys": {
                                                 "description": "Should be either null, in the case where the target is not specified as a task_id and is specified solely through the target_id target_metadata property or an object with one or more properties, the names of which match task_id variable(s) named within the same model_tasks object. Each property should have one specified value. Each value, or the combination of values if multiple keys are specified, define a single target value.",
-                                                "examples": [{
+                                                "examples": [
+                                                    {
                                                         "target": "inc hosp"
                                                     },
                                                     {
@@ -1344,7 +1417,8 @@
                     },
                     "submissions_due": {
                         "description": "Object defining the dates by which model forecasts must be submitted to the hub.",
-                        "examples": [{
+                        "examples": [
+                            {
                                 "start": "2022-06-07",
                                 "end": "2022-07-20"
                             },
@@ -1355,7 +1429,8 @@
                             }
                         ],
                         "type": "object",
-                        "oneOf": [{
+                        "oneOf": [
+                            {
                                 "properties": {
                                     "relative_to": {
                                         "description": "Name of task id variable in relation to which submission start and end dates are calculated.",
@@ -1411,8 +1486,13 @@
                     "file_format": {
                         "description": "Accepted file formats of model output files for the round. Overrides the file formats provided in admin.json.",
                         "examples": [
-                            ["arrow", "parquet"],
-                            ["csv"]
+                            [
+                                "arrow",
+                                "parquet"
+                            ],
+                            [
+                                "csv"
+                            ]
                         ],
                         "type": "array",
                         "items": {
@@ -1437,14 +1517,16 @@
         "output_type_id_datatype": {
             "description": "The hub level data type of the output_type_id column. This data type must be shared across all files in the hub and be able to represent all output type ID values across all hub output types and rounds. If not provided or set to 'auto', hub defaults to autodetecting the simplest hub level data type.",
             "default": "auto",
-            "examples": ["character"],
+            "examples": [
+                "character"
+            ],
             "type": "string",
             "enum": [
                 "auto",
-                "character", 
-                "double", 
+                "character",
+                "double",
                 "integer",
-                "logical", 
+                "logical",
                 "Date"
             ]
         }


### PR DESCRIPTION
I used the following commands to un-collapse any arrays in the schema files:
```
jq -c --indent 4 . v3.0.1/tasks-schema.json | sponge v3.0.1/tasks-schema.json
jq -c --indent 4 . v3.0.1/admin-schema.json | sponge v3.0.1/admin-schema.json
```

This does not change any of the content of the files, just the formatting but will allow diffs in #103 to be show up correctly.