### PR TITLE
Restrict `target_keys` object to contain only a single key value pair. 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 This release contains the following non-breaking changes: 
 
 * Added explicit checks of `round_id` format through a regex `pattern` check to the `round.round_id` property when `round.round_id_from_variable` is `false`. This provides upfront validation of the expected format of manual round IDs (i.e. those not source from a task ID) (#112).
+* Restricted the `target_keys` object to contain only a single key value pair (if not `null`). This means that target keys can now only consist of a single value from a single task ID (#117).
 
 # v4.0.0
 

--- a/v4.0.1/tasks-schema.json
+++ b/v4.0.1/tasks-schema.json
@@ -1290,20 +1290,14 @@
                                                     {
                                                         "target": "peak week hosp"
                                                     },
-                                                    {
-                                                        "target_variable": "hosp",
-                                                        "target_outcome": "inc"
-                                                    },
-                                                    {
-                                                        "target_variable": "case",
-                                                        "target_outcome": "peak week"
-                                                    },
                                                     null
                                                 ],
                                                 "type": [
                                                     "object",
                                                     "null"
                                                 ],
+                                                "minProperties": 1,
+                                                "maxProperties": 1,
                                                 "additionalProperties": {
                                                     "type": "string"
                                                 }


### PR DESCRIPTION
This PR resolves #117 by restricting `target_keys` objects to contain only a single key value pair. 

Successful validation is demonstrated in `hubAdmin` PR https://github.com/hubverse-org/hubAdmin/pull/90 and more specifically in these [tests](https://github.com/hubverse-org/hubAdmin/blob/25b01c583f1ea007490360984de3f7f700075030/tests/testthat/test-validate_config.R#L255-L285) using [this](https://github.com/hubverse-org/hubAdmin/blob/6192af2453f4800ada05b0e786aebf3ceb179634/tests/testthat/testdata/v4.0.1-tasks-2-target_keys.json#L1-L164) and [this](https://github.com/hubverse-org/hubAdmin/blob/25b01c583f1ea007490360984de3f7f700075030/tests/testthat/testdata/v4.0.1-tasks-null-target_keys.json#L1-L93) test file.

### Question

Should we also remove `target_variable` and `target_outcome` from the schema? These were originally added as standard task ids (and are[ documented as such in hubDocs](https://hubverse.io/en/latest/user-guide/tasks.html#standard-task-id-variables)) for the following reason:

> `target_variable/target_outcome`: task IDs making up unique identifiers of a two-part target. These tasks can be used in hubs that want to divide the definition of a target across two variables. Both task IDs will be specified as target keys in the [`target_metadata` array](#tasks-metadata).

The answer also therefore has implications on https://github.com/hubverse-org/hubDocs/issues/226

