### PR TITLE
Update links to docs.hubverse.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <!--- Badges-end --->
 
 
-This repository houses JSON schemas for [the Consortium of Infectious Disease Modeling Hubs](https://github.com/hubverse-org). These schemas define the specifications for the configuration files that are required to be present in a modeling hub. Full documentation about modeling hubs can be found at [the Modeling Hub documentation site](https://hubverse.io/en/latest/), with some [specific documentation about the schema files](https://hubverse.io/en/latest/user-guide/hub-config.html).
+This repository houses JSON schemas for [the Consortium of Infectious Disease Modeling Hubs](https://github.com/hubverse-org). These schemas define the specifications for the configuration files that are required to be present in a modeling hub. Full documentation about modeling hubs can be found at [the Modeling Hub documentation site](https://docs.hubverse.io/en/latest/), with some [specific documentation about the schema files](https://docs.hubverse.io/en/latest/user-guide/hub-config.html).
 
 # Versioning
 
@@ -15,7 +15,7 @@ Wen creating new versions and making changes to the schema file, make sure to re
 ## Schema documentation
 
 
-The [`HubDocs`](https://hubverse.io/en/latest/index.html) documentation site is the primary location for documenting schema usage. It is also [versioned by using releases](https://docs.readthedocs.io/en/stable/versions.html) and should track releases in this repository. 
+The [`HubDocs`](https://docs.hubverse.io/en/latest/index.html) documentation site is the primary location for documenting schema usage. It is also [versioned by using releases](https://docs.readthedocs.io/en/stable/versions.html) and should track releases in this repository. 
 
 
 After making a new release to the schema repository, ensure `hubDocs` are also appropriately updated and an associated new release in the `hubDocs` repository also created.


### PR DESCRIPTION
This PR updates `hubverse.io` URLs to point to `docs.hubverse.io`.

📝 Multiple commits — feel free to **Squash and Merge** to keep history clean.